### PR TITLE
Build nextjs app with prisma and tailwindcss

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,12 +36,12 @@
     "@types/node": "^20.0.0",
     "@types/react-dom": "^18.0.0",
     "@types/jsonwebtoken": "^9.0.0",
-    "@types/bcryptjs": "^2.4.0"
-  },
-  "devDependencies": {
+    "@types/bcryptjs": "^2.4.0",
     "tailwindcss": "^3.0.0",
     "postcss": "^8.0.0",
-    "autoprefixer": "^10.0.0",
+    "autoprefixer": "^10.0.0"
+  },
+  "devDependencies": {
     "eslint": "^8.0.0",
     "eslint-config-next": "^14.0.0"
   }


### PR DESCRIPTION
Move TailwindCSS, PostCSS, and Autoprefixer to `dependencies` to fix production build failures.

The build environment sets `NODE_ENV=production`, which prevents `devDependencies` from being installed. Since these packages are essential for Next.js to compile CSS during the build process, they must be listed under `dependencies`.

---
<a href="https://cursor.com/background-agent?bcId=bc-3ce5a618-54a6-4b8d-9f1d-1c1cd5cb8a0d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3ce5a618-54a6-4b8d-9f1d-1c1cd5cb8a0d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

