### PR TITLE
Handle environment variable update failure

### DIFF
--- a/src/app/api/database/settings/route.ts
+++ b/src/app/api/database/settings/route.ts
@@ -45,7 +45,7 @@ export async function POST(request: NextRequest) {
       )
     }
 
-    if (type !== 'sqlite' && type !== 'postgresql') {
+    if (type !== 'sqlite' && type !== 'postgresql' && type !== 'postgresql-local' && type !== 'postgresql-cloud') {
       return NextResponse.json(
         { success: false, error: 'نوع قاعدة البيانات غير صحيح' },
         { status: 400 }
@@ -60,7 +60,7 @@ export async function POST(request: NextRequest) {
       )
     }
 
-    if (type === 'postgresql' && !connectionString.startsWith('postgresql://')) {
+    if ((type === 'postgresql' || type === 'postgresql-local' || type === 'postgresql-cloud') && !connectionString.startsWith('postgresql://')) {
       return NextResponse.json(
         { success: false, error: 'رابط PostgreSQL يجب أن يبدأ بـ postgresql://' },
         { status: 400 }

--- a/src/lib/db-admin.ts
+++ b/src/lib/db-admin.ts
@@ -239,8 +239,11 @@ export async function handleInitOrSwitch(payload: InitOrSwitchPayload): Promise<
       targetUrl = `postgresql://${pg.user}:${pg.password}@${pg.host}:${pg.port}/${pg.database}`
     } else if (type === 'postgresql-cloud' && cloudUrl) {
       targetUrl = cloudUrl
-    } else {
+    } else if (type === 'sqlite') {
       targetUrl = resolveUrlByType(type)
+    } else {
+      // Fallback to environment variable or default
+      targetUrl = process.env.DATABASE_URL || resolveUrlByType(type)
     }
     
     logs.push(`🎯 نوع القاعدة المستهدفة: ${type}`)

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -3,10 +3,8 @@ import { getEnvVars, resolveUrlByType, DbType } from './env'
 
 // Create Prisma client with runtime URL override
 export function createPrismaClient(customUrl?: string) {
-  const env = getEnvVars()
-  
-  // Use custom URL if provided, otherwise resolve from current type
-  const databaseUrl = customUrl || resolveUrlByType(env.DATABASE_TYPE as DbType)
+  // Use custom URL if provided, otherwise use environment variable
+  const databaseUrl = customUrl || process.env.DATABASE_URL || 'file:./prisma/dev.db'
   
   return new PrismaClient({
     datasources: {
@@ -27,9 +25,8 @@ export async function testDatabaseConnection(customUrl?: string) {
   
   try {
     await client.$connect()
-    const env = getEnvVars()
-    console.log(`✅ تم الاتصال بقاعدة البيانات: ${env.DATABASE_TYPE}`)
-    return { success: true, type: env.DATABASE_TYPE }
+    console.log(`✅ تم الاتصال بقاعدة البيانات`)
+    return { success: true }
   } catch (error) {
     console.error('❌ فشل الاتصال بقاعدة البيانات:', error)
     return { 


### PR DESCRIPTION
Update API validation and database URL resolution to support PostgreSQL Cloud.

The "Bad Request" error occurred because the API route `/api/database/settings` did not recognize `postgresql-cloud` as a valid database type. This PR extends the validation to include `postgresql-local` and `postgresql-cloud`, and refines the logic for resolving and testing database URLs during a switch operation to correctly handle PostgreSQL Cloud connections.

---
<a href="https://cursor.com/background-agent?bcId=bc-8e9fe230-2a18-477c-be6b-c353ce72e4be">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8e9fe230-2a18-477c-be6b-c353ce72e4be">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

